### PR TITLE
Move FSHOnline to https://fshonline.fshschool.org/

### DIFF
--- a/.github/workflows/deploy-workflow.yaml
+++ b/.github/workflows/deploy-workflow.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   deploy-to-pages:
@@ -19,9 +20,10 @@ jobs:
         env:
           VITE_BITLY_KEY: ${{ secrets.VITE_BITLY_KEY }}
       - name: Publish build to github pages
-        uses: peaceiris/actions-gh-pages@v3.5.7
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          cname: fshonline.fshschool.org
           publish_dir: dist
           publish_branch: gh-pages
           user_name: 'github-actions[bot]'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # FSH Online
 
-FSH Online is a web application for authoring [FHIR Shorthand (FSH)](https://build.fhir.org/ig/HL7/fhir-shorthand/) and running the [SUSHI](https://github.com/FHIR/sushi) compiler on the authored FSH directly in a web browser. It also runs the [GoFSH](https://github.com/FHIR/GoFSH) decompiler to translate FHIR definitions into FSH. It is available on https://fshschool.org/FSHOnline/.
+FSH Online is a web application for authoring [FHIR Shorthand (FSH)](https://build.fhir.org/ig/HL7/fhir-shorthand/) and running the [SUSHI](https://github.com/FHIR/sushi) compiler on the authored FSH directly in a web browser. It also runs the [GoFSH](https://github.com/FHIR/GoFSH) decompiler to translate FHIR definitions into FSH. It is available on https://fshonline.fshschool.org/.
 
 ## FHIR Foundation Project Statement
 
 - Maintainers: This project is maintained by the HL7 community.
-- Issues / Discussion: For FSH Online issues, such as bug reports, comments, suggestions, questions, and feature requests, visit [FSH Online GitHub Issues](https://github.com/FSHSchool/FSHOnline/issues). For discussion of FHIR Shorthand and its associated projects, visit the FHIR Community Chat @ https://chat.fhir.org. The [#shorthand stream](https://chat.fhir.org/#narrow/stream/215610-shorthand) is used for all FHIR Shorthand questions and discussion.
+- Issues / Discussion: For FSH Online issues, such as bug reports, comments, suggestions, questions, and feature requests, visit [FSH Online GitHub Issues](https://github.com/FHIR/FSHOnline/issues). For discussion of FHIR Shorthand and its associated projects, visit the FHIR Community Chat @ https://chat.fhir.org. The [#shorthand stream](https://chat.fhir.org/#narrow/stream/215610-shorthand) is used for all FHIR Shorthand questions and discussion.
 - License: All contributions to this project will be released under the Apache 2.0 License, and a copy of this license can be found in [LICENSE](LICENSE).
 - Contribution Policy: The FSH Online Contribution Policy can be found in [CONTRIBUTING.md](CONTRIBUTING.md).
 - Security Information: The FSH Online Security Information can be found in [SECURITY.md](SECURITY.md).
@@ -27,11 +27,11 @@ Once the dependencies are installed, the application can be run in development m
 npm start
 ```
 
-Open [http://localhost:5173/FSHOnline/](http://localhost:5173/FSHOnline/) to view it in the browser. The page will reload if you make edits. Lint and prettier errors will appear in the console.
+Open [http://localhost:5173/](http://localhost:5173/) to view it in the browser. The page will reload if you make edits. Lint and prettier errors will appear in the console.
 
 ## FSH Examples
 
-FSH Online supports easily adding FHIR Shorthand examples that can be viewed in the editor. All examples are kept in the [FSHOnline-Examples repo](https://github.com/FSHSchool/FSHOnline-Examples), and FSH authors are encouraged to submit example FSH files to the FSHOnline-Examples repo.
+FSH Online supports easily adding FHIR Shorthand examples that can be viewed in the editor. All examples are kept in the [FSHOnline-Examples repo](https://github.com/FHIR/FSHOnline-Examples), and FSH authors are encouraged to submit example FSH files to the FSHOnline-Examples repo.
 
 ## NPM Tasks
 
@@ -87,7 +87,7 @@ To serve the built application locally for testing, run the following command:
 npm run preview
 ```
 
-This will serve the built application from the `dist` directory. It will be served on port 4173. You can access it at the following URL: [http://localhost:4173/FSHOnline](http://localhost:4173/FSHOnline).
+This will serve the built application from the `dist` directory. It will be served on port 4173. You can access it at the following URL: [http://localhost:4173/](http://localhost:4173/).
 
 ## Learn More
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Reporting security issues privately
 
-To report a security issue privately, please [create a security advisory](https://github.com/FSHSchool/FSHOnline/security/advisories) in this repository. This will allow repository administrators to review and address it privately before public disclosure. For more details about this process, see ["Privately reporting a security vulnerability"](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+To report a security issue privately, please [create a security advisory](https://github.com/FHIR/FSHOnline/security/advisories) in this repository. This will allow repository administrators to review and address it privately before public disclosure. For more details about this process, see ["Privately reporting a security vulnerability"](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
 
 # Project security practices
 

--- a/index.html
+++ b/index.html
@@ -9,12 +9,12 @@
 
     <meta property="og:title" content="FSH Online"/>
     <meta property="og:description" content="A web playground to write and share FHIR Shorthand. It's so fun, you're guaranteed to get hooked!"/>
-    <meta property="og:url" content="/FSHOnline"/>
+    <meta property="og:url" content="https://fshonline.fshschool.org"/>
     <meta property="og:image" content="/FSH-online-logo.png"/>
 
     <meta name="twitter:title" content="FSH Online"/>
     <meta name="twitter:description" content="A web playground to write and share FHIR Shorthand. It's so fun, you're guaranteed to get hooked!"/>
-    <meta property="twitter:url" content="/FSHOnline"/>
+    <meta property="twitter:url" content="https://fshonline.fshschool.org"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:image" content="/FSH-online-logo.png"/>
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "FSH Online",
+  "name": "FSH Online",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,14 +122,13 @@ export async function decodeFSH(encodedFSH) {
     return '';
   } else {
     const promisedURL = await expandLink(encodedFSH);
-
-    // Removes the encoded data from the end of the url, starting at index 40
-    const sliced64 = promisedURL.long_url.slice(40);
-    if (!promisedURL.long_url.includes('https://fshonline.fshschool.org/#/share/') || sliced64.length === 0) {
+    const encodedData = promisedURL.long_url?.match(
+      /^https?:\/\/(fshonline\.fshschool\.org|fshschool\.org\/FSHOnline)\/#\/share\/(.*)/
+    )?.[2];
+    if (!encodedData || encodedData === '') {
       return '';
     } else {
-      const displayText = inflateSync(Buffer.from(sliced64, 'base64')).toString('utf-8');
-      return displayText;
+      return inflateSync(Buffer.from(encodedData, 'base64')).toString('utf-8');
     }
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const githubURL = 'https://raw.githubusercontent.com/FSHSchool/FSHOnline-Examples/main';
+const githubURL = 'https://raw.githubusercontent.com/FHIR/FSHOnline-Examples/main';
 const defaultInfoMessage = 'There are no messages to display in the console.';
 const defaultProblemMessage = 'There are no problems to display in the console.';
 let infoMessages = [defaultInfoMessage];
@@ -123,9 +123,9 @@ export async function decodeFSH(encodedFSH) {
   } else {
     const promisedURL = await expandLink(encodedFSH);
 
-    // Removes the encoded data from the end of the url, starting at index 38
+    // Removes the encoded data from the end of the url, starting at index 40
     const sliced64 = promisedURL.long_url.slice(40);
-    if (!promisedURL.long_url.includes('https://fshschool.org/FSHOnline/#/share/') || sliced64.length === 0) {
+    if (!promisedURL.long_url.includes('https://fshonline.fshschool.org/#/share/') || sliced64.length === 0) {
       return '';
     } else {
       const displayText = inflateSync(Buffer.from(sliced64, 'base64')).toString('utf-8');

--- a/src/components/FSHControls.jsx
+++ b/src/components/FSHControls.jsx
@@ -447,7 +447,7 @@ export default function FSHControls(props) {
         <DialogActions className={classes.dialogActions}>
           <div className={classes.dialogActionsMessage}>
             Have an example that might be bene-fish-al? Seas the day and add to our collection on{' '}
-            <Link href="https://github.com/FSHSchool/FSHOnline-Examples#readme">GitHub</Link>!
+            <Link href="https://github.com/FHIR/FSHOnline-Examples#readme">GitHub</Link>!
           </div>
           <div>
             <Button onClick={handleCopyToClipboard} color="primary">

--- a/src/components/ShareLink.jsx
+++ b/src/components/ShareLink.jsx
@@ -58,7 +58,7 @@ export default function ShareLink(props) {
   const updateGistLink = (event) => {
     const gistId = event.target.value.match(/gist\.github\.com\/[^/]+\/(.+)/)?.[1];
     if (gistId) {
-      setGistLink(`https://fshschool.org/FSHOnline/#/gist/${gistId}`);
+      setGistLink(`https://fshonline.fshschool.org/#/gist/${gistId}`);
     }
   };
 
@@ -116,14 +116,14 @@ export default function ShareLink(props) {
     } else {
       encoded = deflateSync(props.shareText).toString('base64');
     }
-    const longLink = `https://fshschool.org/FSHOnline/#/share/${encoded}`;
+    const longLink = `https://fshonline.fshschool.org/#/share/${encoded}`;
     const bitlyLink = await generateLink(longLink);
     if (bitlyLink.errorNeeded === true) {
       handleShareError();
     } else {
       // Removes the encoded data from the end of the url, starting at index 15
       const bitlySlice = bitlyLink.link.slice(15);
-      const displayLink = `https://fshschool.org/FSHOnline/#/share/${bitlySlice}`;
+      const displayLink = `https://fshonline.fshschool.org/#/share/${bitlySlice}`;
       setLink(displayLink);
       setOpenShare(true);
       setCopyTip('Copy to Clipboard');

--- a/tests/App.test.jsx
+++ b/tests/App.test.jsx
@@ -22,6 +22,43 @@ it('decodeFSH will return a properly decoded string from base64', async () => {
   });
 });
 
+it('decodeFSH will return a properly decoded string for old FSH Online links', async () => {
+  const expandLinkSpy = vi.spyOn(bitlyWorker, 'expandLink').mockReset().mockResolvedValue({
+    long_url: 'https://fshschool.org/FSHOnline/#/share/eJzzyNRRKMnILFYAokSFktTiEoW0/CKFlNTk/JTMvHQ9ALALCwU='
+  });
+  const base64 = '2Lpe5ZL';
+  const decoded = await decodeFSH(base64);
+  const expectedDecoded = 'Hi, this is a test for decoding.';
+  await waitFor(() => {
+    expect(decoded).toEqual(expectedDecoded);
+    expect(expandLinkSpy).toHaveBeenCalled();
+  });
+});
+
+it('decodeFSH will return an empty string if there is no encoded content in URL', async () => {
+  const expandLinkSpy = vi.spyOn(bitlyWorker, 'expandLink').mockReset().mockResolvedValue({
+    long_url: 'https://fshonline.fshschool.org/#/share/'
+  });
+  const base64 = '2Lpe5ZL';
+  const decoded = await decodeFSH(base64);
+  await waitFor(() => {
+    expect(decoded).toEqual('');
+    expect(expandLinkSpy).toHaveBeenCalled();
+  });
+});
+
+it('decodeFSH will return an empty string for a non-FSHOnline link', async () => {
+  const expandLinkSpy = vi.spyOn(bitlyWorker, 'expandLink').mockReset().mockResolvedValue({
+    long_url: 'https://hl7.org/fhir/'
+  });
+  const base64 = '2Lpe5ZL';
+  const decoded = await decodeFSH(base64);
+  await waitFor(() => {
+    expect(decoded).toEqual('');
+    expect(expandLinkSpy).toHaveBeenCalled();
+  });
+});
+
 it('line wrapping selection is reflected in parent on selection of checkbox', async () => {
   const { container, getByRole, getByLabelText } = render(<App match={{}} />);
   // wrapping not set by default

--- a/tests/App.test.jsx
+++ b/tests/App.test.jsx
@@ -11,7 +11,7 @@ it('basic app renders', () => {
 
 it('decodeFSH will return a properly decoded string from base64', async () => {
   const expandLinkSpy = vi.spyOn(bitlyWorker, 'expandLink').mockReset().mockResolvedValue({
-    long_url: 'https://fshschool.org/FSHOnline/#/share/eJzzyNRRKMnILFYAokSFktTiEoW0/CKFlNTk/JTMvHQ9ALALCwU='
+    long_url: 'https://fshonline.fshschool.org/#/share/eJzzyNRRKMnILFYAokSFktTiEoW0/CKFlNTk/JTMvHQ9ALALCwU='
   });
   const base64 = '2Lpe5ZL';
   const decoded = await decodeFSH(base64);

--- a/tests/AppRouter.test.jsx
+++ b/tests/AppRouter.test.jsx
@@ -5,9 +5,9 @@ import AppRouter from '../src/AppRouter';
 
 vi.mock('../src/App.jsx', () => ({ default: () => <div>Mock FSH Online</div> }));
 
-test('Renders FSH Online App when visiting /FSHOnline', () => {
+test('Renders FSH Online App when visiting /', () => {
   const { getByText } = render(
-    <MemoryRouter initialEntries={['/FSHOnline']}>
+    <MemoryRouter initialEntries={['/']}>
       <AppRouter />
     </MemoryRouter>
   );
@@ -15,9 +15,9 @@ test('Renders FSH Online App when visiting /FSHOnline', () => {
   expect(linkElement).toBeInTheDocument();
 });
 
-test('Renders FSH Online App when visiting /FSHOnline/share/:text', () => {
+test('Renders FSH Online App when visiting /share/:text', () => {
   const { getByText } = render(
-    <MemoryRouter initialEntries={['/FSHOnline/share/abcd']}>
+    <MemoryRouter initialEntries={['/share/abcd']}>
       <AppRouter />
     </MemoryRouter>
   );
@@ -25,9 +25,9 @@ test('Renders FSH Online App when visiting /FSHOnline/share/:text', () => {
   expect(linkElement).toBeInTheDocument();
 });
 
-test('Renders FSH Online App when visiting /FSHOnline/gist/:id', () => {
+test('Renders FSH Online App when visiting /gist/:id', () => {
   const { getByText } = render(
-    <MemoryRouter initialEntries={['/FSHOnline/gist/123']}>
+    <MemoryRouter initialEntries={['/gist/123']}>
       <AppRouter />
     </MemoryRouter>
   );

--- a/tests/components/FSHControls.test.jsx
+++ b/tests/components/FSHControls.test.jsx
@@ -506,7 +506,7 @@ it('should include a link to the examples repo', () => {
   expect(exampleRepoText).toBeInTheDocument();
   const exampleRepoUrl = getByRole('link');
   expect(exampleRepoUrl).toBeInTheDocument();
-  expect(exampleRepoUrl).toHaveAttribute('href', 'https://github.com/FSHSchool/FSHOnline-Examples#readme');
+  expect(exampleRepoUrl).toHaveAttribute('href', 'https://github.com/FHIR/FSHOnline-Examples#readme');
 });
 
 it.skip('should populate editor when examples are collected', async () => {
@@ -526,12 +526,12 @@ it.skip('should populate editor when examples are collected', async () => {
     'manifestchild-1': {
       name: 'manifestchild-1',
       description: 'First manifest object',
-      path: 'https://raw.githubusercontent.com/FSHSchool/FSHOnline-Examples/main/Aliases/FHIR-aliases.fsh'
+      path: 'https://raw.githubusercontent.com/FHIR/FSHOnline-Examples/main/Aliases/FHIR-aliases.fsh'
     },
     'manifestchild-2': {
       name: 'manifestchild-2',
       description: 'Second manifest object',
-      path: 'https://raw.githubusercontent.com/FSHSchool/FSHOnline-Examples/main/Aliases/External-aliases.fsh'
+      path: 'https://raw.githubusercontent.com/FHIR/FSHOnline-Examples/main/Aliases/External-aliases.fsh'
     }
   };
 

--- a/tests/components/ShareLink.test.jsx
+++ b/tests/components/ShareLink.test.jsx
@@ -59,7 +59,7 @@ it('generates direct link with configuration when direct link button is clicked'
   });
   await waitFor(() => {
     expect(deflateSpy).toHaveBeenCalledWith('{"c":"http://example.org"}\nProfile: A');
-    expect(generateLinkSpy).toHaveBeenCalledWith('https://fshschool.org/FSHOnline/#/share/foo');
+    expect(generateLinkSpy).toHaveBeenCalledWith('https://fshonline.fshschool.org/#/share/foo');
   });
 });
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -5,7 +5,7 @@ import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/FSHOnline/',
+  base: '/',
   build: {
     chunkSizeWarningLimit: 4000,
     rollupOptions: {


### PR DESCRIPTION
**Description:** The FSHOnline and FSHOnline-Examples repos are moving to the GitHub FHIR organization. Due to how GitHub pages work, this necessitates moving FSH Online from https://fshschool.org/FSHOnline to https://fshonline.fshschool.org. This PR contains the changes necessary to serve the app at that subdomain, as well as changing links from github.com/FSHSchool/* to github.com/FHIR/*.

The PR should only be merged _after_ the repositories have been moved to the github.com/FHIR organization. In addition to merging this PR, the fshschool.org domain will need to be configured as described [here](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).
* Note since we are using a static generated site, you can skip step 4.
* In step 5, you should create a DNS `CNAME` record to point `fshonline.fshschool.org` to `fhir.github.io`.

**Testing Instructions:** The tests should pass and you should still be able to run this app locally. Note that now you test the app at the root of the URL, not at the /FSHOnline subpath. Also note that Examples will not work until _after_ the repos are moved -- so if you are testing _before_ the repos move, then you should not expect to see any content in the Examples modal.

**Related Issue:** N/A
