### PR TITLE
Avoid using an object when displaying id in JSON editor sidebar

### DIFF
--- a/src/components/JSONEditor.jsx
+++ b/src/components/JSONEditor.jsx
@@ -116,7 +116,15 @@ const checkFshType = (def) => {
 
 const checkIdToDisplay = (def) => {
   if (def.id) {
-    return def.id;
+    if (typeof def.id === 'object') {
+      // NOTE: This case shouldn't really happen -- it only comes up when id was assigned using an inline instance
+      if (def.id.value) {
+        return def.id.value;
+      }
+    } else {
+      // Typical case
+      return def.id;
+    }
   }
   if (def.resourceType) {
     // Logical Model instances don't always have an id, so fall back to last part of the resourceType

--- a/tests/components/JSONEditor.test.jsx
+++ b/tests/components/JSONEditor.test.jsx
@@ -402,6 +402,43 @@ describe('file tree display', () => {
     expect(untitledDef).toBeInTheDocument();
   });
 
+  // NOTE: This is not a typical case -- but just check that it works so that FSH Online doesn't crash if an inline instance is assigned to id
+  it('displays the id.value if definition id is an object', () => {
+    const profileWithObjectId = {
+      profiles: [
+        {
+          resourceType: 'StructureDefinition',
+          id: { value: 'example-object-id' } // object id with a value to use as id
+        },
+        {
+          resourceType: 'StructureDefinition',
+          id: { extension: [{ valueString: 'do not display this as an id' }] } // object without a value to use as id
+        }
+      ],
+      extensions: [],
+      logicals: [],
+      resources: [],
+      instances: [],
+      valueSets: [],
+      codeSystems: []
+    };
+    const { getByText } = render(
+      <JSONEditor
+        showNewText={true}
+        setShowNewText={() => {}}
+        isWaiting={false}
+        updateTextValue={() => {}}
+        text={JSON.stringify(profileWithObjectId, null, 2)}
+      />,
+      container
+    );
+
+    const structureDef = getByText('example-object-id');
+    expect(structureDef).toBeInTheDocument();
+    const exampleLM = getByText('Instance of StructureDefinition');
+    expect(exampleLM).toBeInTheDocument();
+  });
+
   it('sorts a definition to Unknown Type if a definition does not have a resourceType', () => {
     const profileWithoutId = {
       profiles: [


### PR DESCRIPTION
**Description:**
This PR avoids returning an object as the `id` value that is used when we display FHIR artifacts in the JSON editor sidebar.

When an `id` is set using an instance, the `id` property is an object, not a string. However, FSH Online assumed `id` was always a string value and passed it to components assuming it was a string.

To handle this, I updated the `checkIdToDisplay` function that we use to determine an `id` value to better handle objects.

**Testing Instructions:**
The main goal of this PR was just to prevent FSH Online from crashing. You can test this by using the following FSH:

```
Instance: MyId
InstanceOf: string
Usage: #inline
* value = "my-id"

Instance: MyObs
InstanceOf: Observation
* id = MyId
* code = #123
* status = #final
```
On master (and the deployed FSH Online), running SUSHI on this FSH will cause FSH Online to crash. On this branch, it should work and use `my-id` as the value in the sidebar.

The goal of this wasn't to make SUSHI work any better, so there is still an error you'll see coming from SUSHI, and if you run SUSHI in a terminal, the files it creates is probably named wrong, but I just wanted to avoid a full crash of the website.

**Related Issue:** N/A
