### PR TITLE
console debug log level

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -166,6 +166,7 @@ export default function App(props) {
   const [configToShare, setConfigToShare] = useState({ canonical: '', version: '', fhirVersion: [], dependencies: '' });
   const [sharedConfig, setSharedConfig] = useState({});
   const [isLineWrapped, setIsLineWrapped] = useState(false);
+  const [isDebugConsoleChecked, setIsDebugConsoleChecked] = useState(false);
 
   useEffect(() => {
     async function waitForFSH() {
@@ -267,6 +268,10 @@ export default function App(props) {
     setIsLineWrapped(wrapSelected);
   }
 
+  function setDebugConsoleChecked(debugSelected) {
+    setIsDebugConsoleChecked(debugSelected);
+  }
+
   function debouncedMove(clientX) {
     if (isDragging) {
       const newPercentage = (clientX / window.innerWidth) * 100;
@@ -365,6 +370,8 @@ export default function App(props) {
             saveAll={saveAll}
             setIsLineWrapped={setLineWrap}
             isLineWrapped={isLineWrapped}
+            setIsDebugConsoleChecked={setDebugConsoleChecked}
+            isDebugConsoleChecked={isDebugConsoleChecked}
           />
         </div>
         <div className={expandConsole ? classes.collapsedMain : classes.expandedMain}>

--- a/src/components/FSHControls.jsx
+++ b/src/components/FSHControls.jsx
@@ -198,7 +198,12 @@ export default function FSHControls(props) {
       FSHOnly: true,
       fhirVersion: fhirVersion ? [fhirVersion] : ['4.0.1']
     };
-    const outPackage = await runSUSHI(props.fshText, config, parsedDependencies);
+    const outPackage = await runSUSHI(
+      props.fshText,
+      config,
+      parsedDependencies,
+      props.isDebugConsoleChecked ? 'debug' : 'info'
+    );
     let jsonOutput = JSON.stringify(outPackage, replacer, 2);
     if (outPackage && outPackage.codeSystems) {
       if (
@@ -244,7 +249,7 @@ export default function FSHControls(props) {
     }
 
     const options = { dependencies: parsedDependencies, indent: isGoFSHIndented };
-    const { fsh, config } = await runGoFSH(gofshInputStrings, options);
+    const { fsh, config } = await runGoFSH(gofshInputStrings, options, props.isDebugConsoleChecked ? 'debug' : 'info');
     props.onGoFSHClick(fsh, false);
     setIsGoFSHRunning(false);
     if (canonical === '' && config.canonical) setCanonical(config.canonical);

--- a/src/components/FSHControls.jsx
+++ b/src/components/FSHControls.jsx
@@ -177,6 +177,11 @@ export default function FSHControls(props) {
     props.setIsLineWrapped(isLineWrappedChecked);
   };
 
+  const updateConsoleMessageLevel = (event) => {
+    const isDebugConsoleChecked = event.target.checked;
+    props.setIsDebugConsoleChecked(isDebugConsoleChecked);
+  };
+
   async function handleSUSHIClick() {
     if (props.isWaiting) {
       // If SUSHI or GoFSH is in the middle of processes, don't do anything
@@ -401,6 +406,14 @@ export default function FSHControls(props) {
             onChange={updateLineWrapping}
           />
           <FormHelperText>If set, FSH Online will display code with line wrapping</FormHelperText>
+          <FormControlLabel
+            id="debugLevelConsole"
+            margin="dense"
+            control={<Checkbox checked={props.isDebugConsoleChecked} color="primary" />}
+            label="Debug level console messages"
+            onChange={updateConsoleMessageLevel}
+          />
+          <FormHelperText>If set, FSH Online will display debug level messages within the console</FormHelperText>
         </DialogContent>
         <DialogActions>
           <Button onClick={handleCloseConfig} color="primary">

--- a/src/utils/FSHHelpers.js
+++ b/src/utils/FSHHelpers.js
@@ -26,9 +26,9 @@ const FHIRDefinitions = fhirdefs.FHIRDefinitions;
  * indent: user set, defaults to false
  * @returns {string} the FSH
  */
-export async function runGoFSH(input, options) {
+export async function runGoFSH(input, options, loggerLevel) {
   gofshStats.reset();
-  setCurrentLogger('gofsh');
+  setCurrentLogger('gofsh', loggerLevel);
 
   // Read in the resources as strings
   const docs = [];
@@ -92,9 +92,9 @@ export async function runGoFSH(input, options) {
  *
  * @returns Package with FHIR resources
  */
-export async function runSUSHI(input, config, dependencies = []) {
+export async function runSUSHI(input, config, dependencies = [], loggerLevel) {
   sushiStats.reset();
-  setCurrentLogger('sushi');
+  setCurrentLogger('sushi', loggerLevel);
 
   // Load dependencies
   let defs = new FHIRDefinitions();

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -5,10 +5,11 @@ import { utils as gofshUtils } from 'gofsh';
 // between the loggers so that any file can import one logger
 // and have the stats tracked correctly
 export let fshOnlineLogger = sushiUtils.logger;
-export function setCurrentLogger(loggerName) {
+export function setCurrentLogger(loggerName, loggerLevel) {
   if (loggerName === 'sushi') {
     fshOnlineLogger = sushiUtils.logger;
   } else if (loggerName === 'gofsh') {
     fshOnlineLogger = gofshUtils.logger;
   }
+  fshOnlineLogger.level = loggerLevel;
 }


### PR DESCRIPTION
**Description:** This PR adds a debug log level option to the configuration settings menu to allow a user to toggle the debug level messages that appear in the console.

**Testing Instructions:** Run jest unit tests and view within browser.

**Related Issue:** n/a
