### PR TITLE
Color level of log message

### DIFF
--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -20,25 +20,18 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'scroll',
     boxSizing: 'border-box'
   },
-  button: {
-    marginRight: '10px',
-    color: theme.palette.common.white,
-    textTransform: 'none',
-    padding: 0
-  },
-  problemsButton: {
-    padding: 0,
-    color: theme.palette.common.white,
-    textTransform: 'none'
-  },
+  button: { marginRight: '10px', color: theme.palette.common.white, textTransform: 'none', padding: 0 },
+  problemsButton: { padding: 0, color: theme.palette.common.white, textTransform: 'none' },
   expandIcon: {
     width: '29px', // Lines up with padding,
     color: theme.palette.common.white,
     padding: 0
   },
-  pre: {
-    margin: '0px'
-  },
+  pre: { margin: '0px' },
+  error: { background: theme.palette.common.red, paddingRight: '0.4em', paddingLeft: '0.2em' },
+  warn: { background: theme.palette.common.orange, paddingRight: '1em', paddingLeft: '0.2em' },
+  info: { background: theme.palette.common.green, paddingRight: '1em', paddingLeft: '0.2em' },
+  debug: { background: theme.palette.common.blue, paddingRight: '0.4em', paddingLeft: '0.2em' },
   circle: {
     'border-radius': '50%',
     'border-style': 'solid',
@@ -59,6 +52,7 @@ const useStyles = makeStyles((theme) => ({
 export default function Console(props) {
   const classes = useStyles();
   const [problemsView, setProblemsView] = useState(false);
+  const [messages, setMessages] = useState([]);
   const { problemCount, setExpandConsole } = props;
 
   useEffect(() => {
@@ -69,6 +63,23 @@ export default function Console(props) {
       setExpandConsole(true);
     }
   }, [problemCount, setExpandConsole]);
+
+  useEffect(() => {
+    const updatedMessages = (problemsView ? props.problemMessages : props.consoleMessages).map((message) => {
+      if (message.startsWith('error')) {
+        return { logLevel: 'error', consoleMessage: message.slice(5) };
+      } else if (message.startsWith('warn')) {
+        return { logLevel: 'warn', consoleMessage: message.slice(4) };
+      } else if (message.startsWith('info')) {
+        return { logLevel: 'info', consoleMessage: message.slice(4) };
+      } else if (message.startsWith('debug')) {
+        return { logLevel: 'debug', consoleMessage: message.slice(5) };
+      } else {
+        return { logLevel: '', consoleMessage: message };
+      }
+    });
+    setMessages(updatedMessages);
+  }, [props.consoleMessages, props.problemMessages, problemsView]);
 
   const toggleExpandConsole = () => {
     props.setExpandConsole(!props.expandConsole);
@@ -84,6 +95,15 @@ export default function Console(props) {
     props.setExpandConsole(true);
   };
 
+  const renderMessage = (message, i) => {
+    return (
+      <pre key={i} className={classes.pre}>
+        {message.logLevel && <span className={classes[message.logLevel]}>{message.logLevel}</span>}
+        {message.consoleMessage}
+      </pre>
+    );
+  };
+
   return (
     <>
       <Box className={classes.consoleControls}>
@@ -95,12 +115,7 @@ export default function Console(props) {
           {props.expandConsole ? <ExpandMore /> : <ExpandLess />}
         </IconButton>
         <Button onClick={setMessagesConsole} className={classes.button}>
-          <p
-            style={{
-              borderBottom: props.expandConsole && !problemsView ? '1px solid white' : 'none',
-              margin: '0'
-            }}
-          >
+          <p style={{ borderBottom: props.expandConsole && !problemsView ? '1px solid white' : 'none', margin: '0' }}>
             Console
           </p>
         </Button>
@@ -125,21 +140,7 @@ export default function Console(props) {
         </Button>
       </Box>
       <Box style={{ display: props.expandConsole ? 'block' : 'none' }} className={classes.box}>
-        {problemsView
-          ? props.problemMessages.map((message, i) => {
-              return (
-                <pre key={i} className={classes.pre}>
-                  {message}
-                </pre>
-              );
-            })
-          : props.consoleMessages.map((message, i) => {
-              return (
-                <pre key={i} className={classes.pre}>
-                  {message}
-                </pre>
-              );
-            })}
+        {messages.map((message, i) => renderMessage(message, i))}
       </Box>
     </>
   );

--- a/src/theme.js
+++ b/src/theme.js
@@ -11,7 +11,9 @@ const colors = {
   grey: '#575B5C',
   darkerGrey: '#3D4345',
   darkestGrey: '#121D21',
-  red: '#FD6668'
+  red: '#FD6668',
+  green: '#50C878',
+  orange: '#FFB347'
 };
 
 const theme = createTheme({

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: 'tests/setupTests.js'
+    setupFiles: 'tests/setupTests.js',
+    silent: true
   }
 });


### PR DESCRIPTION
**Description:**
This is a small PR to add a block of color over the log level for messages in the Console.

Note that the "results" box isn't colored like it is for SUSHI and GoFSH in the terminal.

**Testing Instructions:**
Try out FSH Online and view different messages at different log levels. Make sure to view an info, error, warning, and debug level message.

**Related Issue:** 
Fixes #180 (with the exception of coloring the results box).